### PR TITLE
Add `bare-rpc/constants` export

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
       "default": "./index.js"
     },
     "./package": "./package.json",
+    "./constants": "./lib/constants.js",
     "./errors": {
       "types": "./lib/errors.d.ts",
       "default": "./lib/errors.js"


### PR DESCRIPTION
## Summary
- Adds `./constants` to the package exports map so consumers can import the protocol constants (`type` and `stream` enums) without reaching into `lib/`.

## Motivation
Mirrors the existing `./messages` export. Without this, downstream tools (e.g., the JS interop fixture generator in `bare-rpc-swift`) have to either inline the constants or reach in via a relative path that couples them to internal layout.