### PR TITLE
Bump `compact-encoding` to `3.0.0`

### DIFF
--- a/lib/messages.js
+++ b/lib/messages.js
@@ -114,7 +114,7 @@ exports.message = {
       case t.REQUEST: {
         const command = c.uint.decode(state)
         const stream = c.uint.decode(state)
-        const data = stream === 0 ? c.buffer.decode(state) : null
+        const data = stream === 0 ? c.optionalBuffer.decode(state) : null
 
         return { type, id, command, stream, data }
       }
@@ -128,7 +128,7 @@ exports.message = {
         }
 
         if (stream === 0) {
-          return { type, id, stream, error: null, data: c.buffer.decode(state) }
+          return { type, id, stream, error: null, data: c.optionalBuffer.decode(state) }
         }
 
         return { type, id, stream, error: null, data: null }
@@ -142,7 +142,7 @@ exports.message = {
         }
 
         if (stream & s.DATA) {
-          return { type, id, stream, error: null, data: c.buffer.decode(state) }
+          return { type, id, stream, error: null, data: c.optionalBuffer.decode(state) }
         }
 
         return { type, id, stream, error: null, data: null }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "dependencies": {
     "b4a": "^1.6.6",
     "bare-stream": "^2.1.3",
-    "compact-encoding": "^2.15.0",
+    "compact-encoding": "^3.0.0",
     "safety-catch": "^1.0.2"
   },
   "devDependencies": {


### PR DESCRIPTION
Adjusted request & response encodings to use `optionalBuffer` encoder since they depend on them.

Tests that failed without the encoder adjustments:

- `empty request`
- `empty response`