### PR TITLE
fix: null-guard request stream lookups in _onstream* handlers

### DIFF
--- a/index.js
+++ b/index.js
@@ -256,7 +256,7 @@ module.exports = exports = class RPC {
 
       stream = request._requestStream
 
-      if (stream._pendingOpen === null) {
+      if (stream === null || stream._pendingOpen === null) {
         this._pendingRequests.add(message.id)
         return
       }
@@ -269,7 +269,7 @@ module.exports = exports = class RPC {
 
       stream = request._responseStream
 
-      if (stream._pendingOpen === null) {
+      if (stream === null || stream._pendingOpen === null) {
         this._pendingResponses.add(message.id)
         return
       }
@@ -297,6 +297,7 @@ module.exports = exports = class RPC {
       return
     }
 
+    if (stream === null) return
     if (message.error) stream.destroy(message.error)
     else stream.push(null)
   }
@@ -318,6 +319,7 @@ module.exports = exports = class RPC {
       return
     }
 
+    if (stream === null) return
     stream.cork()
   }
 
@@ -338,6 +340,7 @@ module.exports = exports = class RPC {
       return
     }
 
+    if (stream === null) return
     stream.uncork()
   }
 
@@ -358,6 +361,7 @@ module.exports = exports = class RPC {
       return
     }
 
+    if (stream === null) return
     if (stream.push(message.data) === false) {
       this._sendMessage({
         type: t.STREAM,
@@ -386,6 +390,7 @@ module.exports = exports = class RPC {
       return
     }
 
+    if (stream === null) return
     stream.push(null)
   }
 
@@ -406,6 +411,7 @@ module.exports = exports = class RPC {
       return
     }
 
+    if (stream === null) return
     stream.destroy(message.error)
   }
 


### PR DESCRIPTION
Inbound STREAM frames can reference a request whose `_requestStream` / `_responseStream` is still the constructor-default `null` — either because the matching `createRequestStream()` / `createResponseStream()` has not been called on this side yet, or because the stream has already been torn down while the peer is still flushing residual control frames for the same id.

Today the seven `_onstream{open,close,pause,resume,data,end,destroy}` handlers all assume the lookup yields a non-null stream and dereference it (`stream._pendingOpen`, `stream.cork()`, `stream.push(...)`, `stream.destroy(...)`).  When the assumption fails the result is a synchronous `TypeError: Cannot read property '...' of null` inside the RPC message loop — and because safety-catch re-throws programmer errors via `queueMicrotask(() => { throw err })`, the exception escapes the `try { _onstream(message) } catch (err) { safetyCatch(err) }` guard in `_onmessage` and ends up as an unhandled rejection at the host application level (FATAL `mqt_v_native` on React Native, an uncaught throw in Node, etc.).

Reproduces deterministically on React Native (Bare iOS / Android test consumer) once enough duplex sessions have churned through a single RPC instance — under sustained load, ~one out of every several hundred inbound stream frames lands in this race window for at least one of the seven handlers and takes down the JS thread.

Match the existing `request === undefined` guard pattern in each handler: when the stream field on the resolved request is null, treat it the same as a missing request and skip the dereference (for `_onstreamopen` that means re-adding the id to `_pendingRequests` / `_pendingResponses` so the matching `OutgoingStream._open(cb)`'s `onflushed` callback can later reconcile; for the other handlers it means the same "no-op until the stream materialises" return path the `request === undefined` case already takes).

No behavioural change in the happy path.