### PR TITLE
Encode null/undefined error code as empty string

### DIFF
--- a/lib/messages.js
+++ b/lib/messages.js
@@ -5,12 +5,12 @@ const errors = require('./errors')
 const error = {
   preencode(state, m) {
     c.utf8.preencode(state, m.message)
-    c.utf8.preencode(state, String(m.code) || '')
+    c.utf8.preencode(state, String(m.code ?? ''))
     c.int.preencode(state, Number(m.errno) || 0)
   },
   encode(state, m) {
     c.utf8.encode(state, m.message)
-    c.utf8.encode(state, String(m.code) || '')
+    c.utf8.encode(state, String(m.code ?? ''))
     c.int.encode(state, Number(m.errno) || 0)
   },
   decode(state) {

--- a/lib/messages.js
+++ b/lib/messages.js
@@ -5,12 +5,12 @@ const errors = require('./errors')
 const error = {
   preencode(state, m) {
     c.utf8.preencode(state, m.message)
-    c.utf8.preencode(state, String(m.code ?? ''))
+    c.utf8.preencode(state, m.code === undefined || m.code === null ? '' : String(m.code))
     c.int.preencode(state, Number(m.errno) || 0)
   },
   encode(state, m) {
     c.utf8.encode(state, m.message)
-    c.utf8.encode(state, String(m.code ?? ''))
+    c.utf8.encode(state, m.code === undefined || m.code === null ? '' : String(m.code))
     c.int.encode(state, Number(m.errno) || 0)
   },
   decode(state) {

--- a/test.js
+++ b/test.js
@@ -3,6 +3,8 @@ const c = require('compact-encoding')
 const { PassThrough } = require('bare-stream')
 const IPC = require('bare-ipc')
 const RPC = require('.')
+const m = require('./lib/messages')
+const { type: messageType } = require('./lib/constants')
 
 test('basic', async (t) => {
   const rpc = new RPC(new PassThrough(), (req) => {
@@ -314,6 +316,30 @@ test('throw an error with string errno', async (t) => {
   req.send('ping')
 
   await t.exception(req.reply(), /Nope/)
+})
+
+test('error with null code round-trips to empty string', (t) => {
+  const error = new Error('Nope')
+  error.code = null
+
+  const message = { type: messageType.RESPONSE, id: 1, stream: 0, error, data: null }
+
+  const encoded = c.encode(m.header, message)
+  const decoded = c.decode(m.message, encoded)
+
+  t.is(decoded.error.code, '')
+})
+
+test('error with undefined code round-trips to empty string', (t) => {
+  const error = new Error('Nope')
+  error.code = undefined
+
+  const message = { type: messageType.RESPONSE, id: 1, stream: 0, error, data: null }
+
+  const encoded = c.encode(m.header, message)
+  const decoded = c.decode(m.message, encoded)
+
+  t.is(decoded.error.code, '')
 })
 
 test('request and reply, ipc', async (t) => {


### PR DESCRIPTION
The error codec used `String(m.code) || ''`, which serializes a null or undefined `code` as the literal string "null"/"undefined" rather than an empty string (`String(null)` is the truthy `"null"`, so the `|| ''` never fires). Switch to `String(m.code ?? '')` so an absent code encodes as `''`. Non-null codes are unaffected; full suite passes under compact-encoding v3.