### PR TITLE
bump hrpc-test to 0.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "bare-buffer": "^3.0.1",
     "bare-ipc": "^1.1.0",
     "brittle": "^3.2.1",
-    "hrpc-test": "^0.0.4",
+    "hrpc-test": "^0.1.0",
     "lunte": "^1.7.0",
     "prettier": "^3.4.2",
     "prettier-config-holepunch": "^2.0.0"


### PR DESCRIPTION
Last hand-written bump for this dep: `^0.1.0` floats across future 0.1.x releases, where `^0.0.x` pinned exactly.

53 tests / 194 asserts.